### PR TITLE
Do not transform elements to be lazy-loaded inside an AJAX response.

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -72,6 +72,21 @@ class Context {
 	}
 
 	/**
+	 * Checks whether the current request is an AJAX request.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True if an AJAX request, false otherwise.
+	 */
+	public function is_ajax() : bool {
+		if ( wp_doing_ajax() ) {
+			return true;
+		}
+
+		return ! empty( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) === 'xmlhttprequest';
+	}
+
+	/**
 	 * Checks whether the current request is for an AMP page.
 	 *
 	 * @since 1.0.0

--- a/src/Context.php
+++ b/src/Context.php
@@ -83,7 +83,8 @@ class Context {
 			return true;
 		}
 
-		return ! empty( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) === 'xmlhttprequest';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return ! empty( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( wp_unslash( $_SERVER['HTTP_X_REQUESTED_WITH'] ) ) === 'xmlhttprequest';
 	}
 
 	/**

--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -67,6 +67,11 @@ class Lazy_Loader {
 	 * @since 1.0.0
 	 */
 	public function register() {
+		// Don't do anything if an AJAX request because lack of context predictability.
+		if ( $this->context->is_ajax() ) {
+			return;
+		}
+
 		// Don't do anything for AMP because it would be unnecessary.
 		if ( $this->context->is_amp() ) {
 			return;

--- a/tests/phpunit/unit/Lazy_Loader_Tests.php
+++ b/tests/phpunit/unit/Lazy_Loader_Tests.php
@@ -29,13 +29,16 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 
 		$this->context = $this->getMockBuilder( Context::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'basename', 'path', 'url', 'is_amp' ] )
+			->setMethods( [ 'basename', 'path', 'url', 'is_ajax', 'is_amp' ] )
 			->getMock();
 
 		$this->lazy_loader = new Lazy_Loader( $this->context );
 	}
 
 	public function test_register() {
+		$this->context->expects( $this->once() )
+			->method( 'is_ajax' )
+			->will( $this->returnValue( false ) );
 		$this->context->expects( $this->once() )
 			->method( 'is_amp' )
 			->will( $this->returnValue( false ) );
@@ -51,6 +54,9 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 	}
 
 	public function test_register_with_fallback_disabled() {
+		$this->context->expects( $this->once() )
+			->method( 'is_ajax' )
+			->will( $this->returnValue( false ) );
 		$this->context->expects( $this->once() )
 			->method( 'is_amp' )
 			->will( $this->returnValue( false ) );


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.7 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Summary

This PR can be summarized in the following changelog entry:

* Do not transform elements inside an AJAX response due to lack of predictability of the context and script execution.

Fixes #1 

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
