### PR TITLE
Run lazy-load script on DOMContentLoaded when necessary, to improve compatibility with plugins like Autoptimize

### DIFF
--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -30,11 +30,14 @@
 						return;
 					}
 					lazyElement.src = lazyElement.dataset.src;
+					delete lazyElement.dataset.src;
 					if ( lazyElement.dataset.srcset ) {
 						lazyElement.srcset = lazyElement.dataset.srcset;
+						delete lazyElement.dataset.srcset;
 					}
 					if ( lazyElement.dataset.sizes ) {
 						lazyElement.sizes = lazyElement.dataset.sizes;
+						delete lazyElement.dataset.sizes;
 					}
 					lazyObserver.unobserve( lazyElement );
 				}
@@ -57,11 +60,14 @@
 						if ( ( lazyElement.getBoundingClientRect().top <= window.innerHeight && 0 <= lazyElement.getBoundingClientRect().bottom ) && 'none' !== getComputedStyle( lazyElement ).display ) {
 							if ( lazyElement.dataset.src ) {
 								lazyElement.src = lazyElement.dataset.src;
+								delete lazyElement.dataset.src;
 								if ( lazyElement.dataset.srcset ) {
 									lazyElement.srcset = lazyElement.dataset.srcset;
+									delete lazyElement.dataset.srcset;
 								}
 								if ( lazyElement.dataset.sizes ) {
 									lazyElement.sizes = lazyElement.dataset.sizes;
+									delete lazyElement.dataset.sizes;
 								}
 							}
 

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -53,36 +53,41 @@ class Lazy_Load_Script {
 		// wait until 'DOMContentLoaded' if it doesn't detect any images to lazy-load initially.
 		?>
 <script type="text/javascript">
-var nativeLazyloadInitialize = function() {
-	var lazyElements, script;
-	if ( 'loading' in HTMLImageElement.prototype ) {
-		lazyElements = [].slice.call( document.querySelectorAll( '.lazy' ) );
-		lazyElements.forEach( function( element ) {
-			if ( ! element.dataset.src ) {
-				return;
-			}
-			element.src = element.dataset.src;
-			if ( element.dataset.srcset ) {
-				element.srcset = element.dataset.srcset;
-			}
-			if ( element.dataset.sizes ) {
-				element.sizes = element.dataset.sizes;
-			}
-		} );
-	} else if ( ! document.querySelector( 'script#native-lazyload-fallback' ) ) {
-		script = document.createElement( 'script' );
-		script.id = 'native-lazyload-fallback';
-		script.type = 'text/javascript';
-		script.src = '<?php echo esc_js( $this->get_fallback_script_url() ); ?>';
-		script.defer = true;
-		document.body.appendChild( script );
+( function() {
+	var nativeLazyloadInitialize = function() {
+		var lazyElements, script;
+		if ( 'loading' in HTMLImageElement.prototype ) {
+			lazyElements = [].slice.call( document.querySelectorAll( '.lazy' ) );
+			lazyElements.forEach( function( element ) {
+				if ( ! element.dataset.src ) {
+					return;
+				}
+				element.src = element.dataset.src;
+				delete element.dataset.src;
+				if ( element.dataset.srcset ) {
+					element.srcset = element.dataset.srcset;
+					delete element.dataset.srcset;
+				}
+				if ( element.dataset.sizes ) {
+					element.sizes = element.dataset.sizes;
+					delete element.dataset.sizes;
+				}
+			} );
+		} else if ( ! document.querySelector( 'script#native-lazyload-fallback' ) ) {
+			script = document.createElement( 'script' );
+			script.id = 'native-lazyload-fallback';
+			script.type = 'text/javascript';
+			script.src = '<?php echo esc_js( $this->get_fallback_script_url() ); ?>';
+			script.defer = true;
+			document.body.appendChild( script );
+		}
+	};
+	if ( document.querySelector( '.lazy' ) ) {
+		nativeLazyloadInitialize();
+	} else {
+		window.addEventListener( 'DOMContentLoaded', nativeLazyloadInitialize );
 	}
-};
-if ( document.querySelector( '.lazy' ) ) {
-	nativeLazyloadInitialize();
-} else {
-	window.addEventListener( 'DOMContentLoaded', nativeLazyloadInitialize );
-}
+}() );
 </script>
 		<?php
 	}

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -78,7 +78,7 @@ var nativeLazyloadInitialize = function() {
 		document.body.appendChild( script );
 	}
 };
-if ( document.querySelector( '.lazy' ) ) {
+if ( document.readyState === 'complete' || document.readyState === 'interactive' ) {
 	nativeLazyloadInitialize();
 } else {
 	window.addEventListener( 'DOMContentLoaded', nativeLazyloadInitialize );

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -45,12 +45,11 @@ class Lazy_Load_Script {
 	 * If the 'loading' attribute is supported by the browser, all elements to lazy-load are prepared for the native
 	 * functionality. Otherwise, the fallback script is loaded into the page.
 	 *
+	 * For maximum compatibility, the script will run once the DOM is ready.
+	 *
 	 * @since 1.0.0
 	 */
 	public function print_script() {
-		// The script is normally loaded after all relevant markup has been printed, so it can run immediately.
-		// However, to cater for third-party plugins that may move the script to e.g. the <head>, the script will
-		// wait until 'DOMContentLoaded' if it doesn't detect any images to lazy-load initially.
 		?>
 <script type="text/javascript">
 ( function() {


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Run lazy-load script on `DOMContentLoaded` when necessary to improve compatibility with plugins like Autoptimize.

Fixes #6 

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
