### PR TITLE
Use more specific class name, and only add it for JS fallback elements

### DIFF
--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -1,5 +1,5 @@
 /**
- * Lazy-load script for anything with a 'lazy' class.
+ * Lazy-load script for anything with a 'native-lazyload-js-fallback' class.
  *
  * @link https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/
  *
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 ( function() {
-	let lazyElements = [].slice.call( document.querySelectorAll( '.lazy' ) );
+	let lazyElements = [].slice.call( document.querySelectorAll( '.native-lazyload-js-fallback' ) );
 
 	if ( 'IntersectionObserver' in window ) {
 		const lazyObserver = new IntersectionObserver( function( entries ) {
@@ -36,6 +36,7 @@
 					if ( lazyElement.dataset.sizes ) {
 						lazyElement.sizes = lazyElement.dataset.sizes;
 					}
+					lazyElement.classList.remove( 'native-lazyload-js-fallback' );
 					lazyObserver.unobserve( lazyElement );
 				}
 			} );
@@ -63,6 +64,7 @@
 								if ( lazyElement.dataset.sizes ) {
 									lazyElement.sizes = lazyElement.dataset.sizes;
 								}
+								lazyElement.classList.remove( 'native-lazyload-js-fallback' );
 							}
 
 							lazyElements = lazyElements.filter( function( element ) {

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -52,7 +52,7 @@ class Lazy_Load_Script {
 <script type="text/javascript">
 if ( 'loading' in HTMLImageElement.prototype ) {
 	( function() {
-		var lazyElements = [].slice.call( document.querySelectorAll( '.lazy' ) );
+		var lazyElements = [].slice.call( document.querySelectorAll( '.native-lazyload-js-fallback' ) );
 		lazyElements.forEach( function( element ) {
 			if ( ! element.dataset.src ) {
 				return;
@@ -64,6 +64,7 @@ if ( 'loading' in HTMLImageElement.prototype ) {
 			if ( element.dataset.sizes ) {
 				element.sizes = element.dataset.sizes;
 			}
+			element.classList.remove( 'native-lazyload-js-fallback' );
 		} );
 	} )();
 } else {
@@ -87,7 +88,7 @@ if ( 'loading' in HTMLImageElement.prototype ) {
 	public function print_style() {
 		?>
 <style type="text/css">
-.no-js .lazy[data-src] {
+.no-js .native-lazyload-js-fallback {
 	display: none;
 }
 </style>

--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -24,7 +24,7 @@ class Lazy_Loader {
 	const LAZYLOAD_FALLBACK_TAGS = 'img';
 
 	// Class to add to all elements to lazy-load.
-	const LAZYLOAD_CLASS = 'lazy';
+	const LAZYLOAD_FALLBACK_CLASS = 'native-lazyload-js-fallback';
 
 	// Class to interpret as blacklist indicator for elements to not lazy-load.
 	const SKIP_LAZYLOAD_CLASS = 'skip-lazy';
@@ -215,13 +215,6 @@ class Lazy_Loader {
 			return $attributes;
 		}
 
-		// Add the lazy class to the img element.
-		if ( ! empty( $attributes['class'] ) ) {
-			$attributes['class'] .= ' ' . static::LAZYLOAD_CLASS;
-		} else {
-			$attributes['class'] = static::LAZYLOAD_CLASS;
-		}
-
 		// Native browser lazy-loading.
 		$attributes['loading'] = 'lazy';
 
@@ -243,6 +236,13 @@ class Lazy_Loader {
 	 * @return array Filtered attributes prepared for lazy-loading.
 	 */
 	protected function filter_lazyload_attributes_for_js_fallback( array $attributes, string $tag = 'img' ) : array {
+		// Add the JS fallback indicator class to the img element.
+		if ( ! empty( $attributes['class'] ) ) {
+			$attributes['class'] .= ' ' . static::LAZYLOAD_FALLBACK_CLASS;
+		} else {
+			$attributes['class'] = static::LAZYLOAD_FALLBACK_CLASS;
+		}
+
 		// Set data-src to the original source uri.
 		$attributes['data-src'] = $attributes['src'];
 

--- a/tests/phpunit/unit/Lazy_Loader_Tests.php
+++ b/tests/phpunit/unit/Lazy_Loader_Tests.php
@@ -130,19 +130,19 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 		return [
 			[
 				'<img src="my-image.jpg">',
-				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" class="lazy" loading="lazy" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg"></noscript>',
+				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" loading="lazy" class="native-lazyload-js-fallback" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg"></noscript>',
 			],
 			[
 				'<img src="my-image.jpg" alt="An alt attribute">',
-				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" alt="An alt attribute" class="lazy" loading="lazy" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg" alt="An alt attribute"></noscript>',
+				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" alt="An alt attribute" loading="lazy" class="native-lazyload-js-fallback" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg" alt="An alt attribute"></noscript>',
 			],
 			[
 				'<img src="my-image.jpg" class="some-class">',
-				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" class="some-class lazy" loading="lazy" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg" class="some-class"></noscript>',
+				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" class="some-class native-lazyload-js-fallback" loading="lazy" data-src="my-image.jpg"><noscript><img loading="lazy" src="my-image.jpg" class="some-class"></noscript>',
 			],
 			[
 				'<img src="my-image.jpg" srcset="a-srcset" sizes="some-sizes"/>',
-				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" class="lazy" loading="lazy" data-src="my-image.jpg" data-srcset="a-srcset" data-sizes="some-sizes"/><noscript><img loading="lazy" src="my-image.jpg" srcset="a-srcset" sizes="some-sizes"/></noscript>',
+				'<img src="' . Lazy_Loader::PLACEHOLDER_PATH . '" loading="lazy" class="native-lazyload-js-fallback" data-src="my-image.jpg" data-srcset="a-srcset" data-sizes="some-sizes"/><noscript><img loading="lazy" src="my-image.jpg" srcset="a-srcset" sizes="some-sizes"/></noscript>',
 			],
 			[
 				'<img src="my-image.jpg" class="skip-lazy">',
@@ -154,11 +154,11 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 			],
 			[
 				'<iframe src="https://example.com"></iframe>',
-				'<iframe src="https://example.com" class="lazy" loading="lazy"></iframe>',
+				'<iframe src="https://example.com" loading="lazy"></iframe>',
 			],
 			[
 				'<iframe src="https://example.com" class="some-class"></iframe>',
-				'<iframe src="https://example.com" class="some-class lazy" loading="lazy"></iframe>',
+				'<iframe src="https://example.com" class="some-class" loading="lazy"></iframe>',
 			],
 			[
 				'<iframe src="https://example.com" class="skip-lazy"></iframe>',
@@ -207,19 +207,19 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 		return [
 			[
 				'<img src="my-image.jpg">',
-				'<img src="my-image.jpg" class="lazy" loading="lazy">',
+				'<img src="my-image.jpg" loading="lazy">',
 			],
 			[
 				'<img src="my-image.jpg" alt="An alt attribute">',
-				'<img src="my-image.jpg" alt="An alt attribute" class="lazy" loading="lazy">',
+				'<img src="my-image.jpg" alt="An alt attribute" loading="lazy">',
 			],
 			[
 				'<img src="my-image.jpg" class="some-class">',
-				'<img src="my-image.jpg" class="some-class lazy" loading="lazy">',
+				'<img src="my-image.jpg" class="some-class" loading="lazy">',
 			],
 			[
 				'<img src="my-image.jpg" srcset="a-srcset" sizes="some-sizes"/>',
-				'<img src="my-image.jpg" srcset="a-srcset" sizes="some-sizes" class="lazy" loading="lazy"/>',
+				'<img src="my-image.jpg" srcset="a-srcset" sizes="some-sizes" loading="lazy"/>',
 			],
 			[
 				'<img src="my-image.jpg" class="skip-lazy">',
@@ -231,11 +231,11 @@ class Lazy_Loader_Tests extends Unit_Test_Case {
 			],
 			[
 				'<iframe src="https://example.com"></iframe>',
-				'<iframe src="https://example.com" class="lazy" loading="lazy"></iframe>',
+				'<iframe src="https://example.com" loading="lazy"></iframe>',
 			],
 			[
 				'<iframe src="https://example.com" class="some-class"></iframe>',
-				'<iframe src="https://example.com" class="some-class lazy" loading="lazy"></iframe>',
+				'<iframe src="https://example.com" class="some-class" loading="lazy"></iframe>',
 			],
 			[
 				'<iframe src="https://example.com" class="skip-lazy"></iframe>',


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Improve compatibility with other plugins by using more specific class and only adding it for JS fallback.

<!-- Please reference the issue this PR addresses. -->
Fixes #4

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
