### PR TITLE
Fix broken images using data URI scheme.

### DIFF
--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -284,7 +284,7 @@ class Lazy_Loader {
 			function( array $attribute ) : string {
 				return $attribute['value'];
 			},
-			wp_kses_hair( $string, array_merge(wp_allowed_protocols(), ['data']) )
+			wp_kses_hair( $string, array_merge( wp_allowed_protocols(), [ 'data' ] ) )
 		);
 	}
 

--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -284,7 +284,7 @@ class Lazy_Loader {
 			function( array $attribute ) : string {
 				return $attribute['value'];
 			},
-			wp_kses_hair( $string, wp_allowed_protocols() )
+			wp_kses_hair( $string, array_merge(wp_allowed_protocols(), ['data']) )
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed broken images which are using data URI scheme (eg. base64 encoded images).

## Relevant technical choices
Due that we use `wp_allowed_protocols` to determine which protocols should be allowed we have two choices. Wether to add a filter to `kses_allowed_protocols` or allowing it static. Later has less sideeffects so I've chosen this way.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [ x ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ - ] My code has proper inline documentation.
