### PR TITLE
Add initial image load in older browser

### DIFF
--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -90,6 +90,7 @@
 			}
 		};
 
+		window.addEventListener('DOMContentLoaded', lazyLoad );
 		document.addEventListener( 'scroll', lazyLoad );
 		window.addEventListener( 'resize', lazyLoad );
 		window.addEventListener( 'orientationchange', lazyLoad );

--- a/assets/js/src/lazyload.js
+++ b/assets/js/src/lazyload.js
@@ -90,7 +90,7 @@
 			}
 		};
 
-		window.addEventListener('DOMContentLoaded', lazyLoad );
+		lazyLoad();
 		document.addEventListener( 'scroll', lazyLoad );
 		window.addEventListener( 'resize', lazyLoad );
 		window.addEventListener( 'orientationchange', lazyLoad );


### PR DESCRIPTION
## Summary
Older browsers like the IE 11 don't support IntersectionObserver, so they use the `lazyLoad` JS function. This function is only executed on scroll, resize and orientationchange event. This PR adds an initial function call, to load the images in the viewport. We don't need to add a `DOMContentLoaded` listener, because the script is appended after this event.

Adresses issue #5 