### PR TITLE
Added escaping in line with VIP Coding Standards

### DIFF
--- a/native-lazyload.php
+++ b/native-lazyload.php
@@ -60,7 +60,7 @@ function native_lazyload_display_php_version_notice() {
 	<div class="notice notice-error">
 		<p>
 			<?php
-			echo sprintf(
+			printf(
 				/* translators: 1: required version, 2: currently used version */
 				esc_html__( 'Native Lazyload requires at least PHP version %1$s. Your site is currently running on PHP %2$s.', 'native-lazyload' ),
 				'7.0',
@@ -82,7 +82,7 @@ function native_lazyload_display_wp_version_notice() {
 	<div class="notice notice-error">
 		<p>
 			<?php
-			echo sprintf(
+			printf(
 				/* translators: 1: required version, 2: currently used version */
 				esc_html__( 'Native Lazyload requires at least WordPress version %1$s. Your site is currently running on WordPress %2$s.', 'native-lazyload' ),
 				'4.7',

--- a/native-lazyload.php
+++ b/native-lazyload.php
@@ -64,7 +64,7 @@ function native_lazyload_display_php_version_notice() {
 				/* translators: 1: required version, 2: currently used version */
 				esc_html__( 'Native Lazyload requires at least PHP version %1$s. Your site is currently running on PHP %2$s.', 'native-lazyload' ),
 				'7.0',
-				phpversion()
+				phpversion() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped 
 			);
 			?>
 		</p>

--- a/native-lazyload.php
+++ b/native-lazyload.php
@@ -60,9 +60,9 @@ function native_lazyload_display_php_version_notice() {
 	<div class="notice notice-error">
 		<p>
 			<?php
-			sprintf(
+			echo sprintf(
 				/* translators: 1: required version, 2: currently used version */
-				__( 'Native Lazyload requires at least PHP version %1$s. Your site is currently running on PHP %2$s.', 'native-lazyload' ),
+				esc_html__( 'Native Lazyload requires at least PHP version %1$s. Your site is currently running on PHP %2$s.', 'native-lazyload' ),
 				'7.0',
 				phpversion()
 			);
@@ -82,11 +82,11 @@ function native_lazyload_display_wp_version_notice() {
 	<div class="notice notice-error">
 		<p>
 			<?php
-			sprintf(
+			echo sprintf(
 				/* translators: 1: required version, 2: currently used version */
-				__( 'Native Lazyload requires at least WordPress version %1$s. Your site is currently running on WordPress %2$s.', 'native-lazyload' ),
+				esc_html__( 'Native Lazyload requires at least WordPress version %1$s. Your site is currently running on WordPress %2$s.', 'native-lazyload' ),
 				'4.7',
-				get_bloginfo( 'version' )
+				esc_html( get_bloginfo( 'version' ) )
 			);
 			?>
 		</p>

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -77,7 +77,7 @@ class Lazy_Load_Script {
 			script = document.createElement( 'script' );
 			script.id = 'native-lazyload-fallback';
 			script.type = 'text/javascript';
-			script.src = '<?php echo esc_js( $this->get_fallback_script_url() ); ?>';
+			script.src = '<?php echo wp_json_encode( esc_url(  $this->get_fallback_script_url() ) ); ?>';
 			script.defer = true;
 			document.body.appendChild( script );
 		}

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -77,7 +77,7 @@ class Lazy_Load_Script {
 			script = document.createElement( 'script' );
 			script.id = 'native-lazyload-fallback';
 			script.type = 'text/javascript';
-			script.src = '<?php echo wp_json_encode( esc_url(  $this->get_fallback_script_url() ) ); ?>';
+			script.src = '<?php echo wp_json_encode( esc_url( $this->get_fallback_script_url() ) ); ?>';
 			script.defer = true;
 			document.body.appendChild( script );
 		}

--- a/src/Lazy_Load_Script.php
+++ b/src/Lazy_Load_Script.php
@@ -77,7 +77,7 @@ class Lazy_Load_Script {
 			script = document.createElement( 'script' );
 			script.id = 'native-lazyload-fallback';
 			script.type = 'text/javascript';
-			script.src = '<?php echo wp_json_encode( esc_url(  $this->get_fallback_script_url() ) ); ?>';
+			script.src = <?php echo wp_json_encode( esc_url( $this->get_fallback_script_url() ) ); ?>;
 			script.defer = true;
 			document.body.appendChild( script );
 		}


### PR DESCRIPTION
For more information, see: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#validation-sanitization-and-escaping

<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.7 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Added late escaping to output.


## Relevant technical choices
For more information, see: https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#validation-sanitization-and-escaping

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
