### PR TITLE
Add filter for overriding image placeholder

### DIFF
--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -265,6 +265,17 @@ class Lazy_Loader {
 
 		// Set placeholder image if applicable.
 		if ( 'img' === $tag ) {
+			/**
+			 * Filters the placeholder image path.
+			 *
+			 * A custom placeholder image can be provided as an absolute URL string.
+			 *
+			 * @since 1.1.0
+			 *
+			 * @param string $path       Default placeholder path.
+			 * @param array  $attributes Attributes of an element to lazy-load.
+			 * @param string $tag        Tag that the attributes are for.
+			 */
 			$attributes['src'] = apply_filters( 'native_lazyload_placeholder', $this->context->url( static::PLACEHOLDER_PATH ), $attributes, $tag );
 		}
 

--- a/src/Lazy_Loader.php
+++ b/src/Lazy_Loader.php
@@ -265,7 +265,7 @@ class Lazy_Loader {
 
 		// Set placeholder image if applicable.
 		if ( 'img' === $tag ) {
-			$attributes['src'] = $this->context->url( static::PLACEHOLDER_PATH );
+			$attributes['src'] = apply_filters( 'native_lazyload_placeholder', $this->context->url( static::PLACEHOLDER_PATH ), $attributes, $tag );
 		}
 
 		return $attributes;


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your code is backward-compatible with WordPress 4.7 and PHP 7.0.
- Make sure your code follows the WordPress coding standards.
- Make sure your code is properly documented.
-->

## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Added filter `native_lazyload_placeholder` to allow overriding the placeholder path.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #22

## Relevant technical choices
<!-- Please describe your changes. -->
Added a filter named `native_lazyload_placeholder` roughly following the precedent set by `native_lazyload_fallback_script_enabled`. This filters the lazyload element's `src` attribute and overrides the hardcoded `PLACEHOLDER_PATH`.

Also, please note that I assumed this would be a minor version bump, so the filter documentation uses `@since 1.1.0`.

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 7.0.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.